### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/libs/index.js
+++ b/libs/index.js
@@ -112,7 +112,7 @@ exports = module.exports = (function(_undefined) {
       jsonData = JSON.parse(jsonData);
     }
     var spliteStr = ".";
-
+    
     if (typeof options === "string") {
       spliteStr = options;
       options = _undefined;
@@ -149,7 +149,7 @@ exports = module.exports = (function(_undefined) {
         jsonData0[key] = val;
       }
     }
-
+    
     for (key in jsonData0) {
       let arr = key.split(spliteStr);
       var d0 = data;
@@ -164,7 +164,7 @@ exports = module.exports = (function(_undefined) {
         } else if (!d0[k0]) {
           d0[k0] = {};
           d0 = d0[k0];
-        } else {
+        } else if (!isPrototypePolluted(k0)) {
           d0 = d0[k0];
         }
       }
@@ -176,3 +176,7 @@ exports = module.exports = (function(_undefined) {
   };
   return json_glat;
 })(undefined);
+
+const isPrototypePolluted = function(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
+}

--- a/libs/index.js
+++ b/libs/index.js
@@ -112,7 +112,7 @@ exports = module.exports = (function(_undefined) {
       jsonData = JSON.parse(jsonData);
     }
     var spliteStr = ".";
-    
+
     if (typeof options === "string") {
       spliteStr = options;
       options = _undefined;
@@ -149,7 +149,7 @@ exports = module.exports = (function(_undefined) {
         jsonData0[key] = val;
       }
     }
-    
+
     for (key in jsonData0) {
       let arr = key.split(spliteStr);
       var d0 = data;


### PR DESCRIPTION
### :bar_chart: Metadata *

`json-glat` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-json-glat

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var jsonGlat = require("json-glat")
console.log("Before : " + {}.polluted);
jsonGlat.parse({'__proto__.polluted': 'Yes! Its Polluted'});
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i json-glat # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104119443-3c10ed80-5355-11eb-82be-176f09890db0.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
